### PR TITLE
Deluxe spinning action

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -49,4 +49,6 @@ $(document).ready(function () {
 	});
 });
 
+var deluxe_spinning_action = new Konami();
+deluxe_spinning_action.load('http://terp.in/');
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -50,5 +50,7 @@ $(document).ready(function () {
 });
 
 var deluxe_spinning_action = new Konami();
-deluxe_spinning_action.load('http://terp.in/');
-
+deluxe_spinning_action.code = function() {
+  $("i").addClass("icon-spin");
+}
+deluxe_spinning_action.load();

--- a/app/assets/stylesheets/profiles.css.scss
+++ b/app/assets/stylesheets/profiles.css.scss
@@ -11,3 +11,7 @@
 .username{
 	font-size: 24pt;
 }
+
+p {
+	word-wrap:break-word;
+}

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -25,14 +25,9 @@
       <%end%>
   </div>
   <div class="span9">
-    <p><%= @profile.about_me %></p>
-    <hr>
-    <% if @profile.solutions.empty? %>
-        <p><%=@profile.user.username %> hasn't submitted any solutions...</p>
-    <% end %>
-    <ul id="solutions">
-      <%= render 'solutions/solutions' %>
-    </ul>
+    <div class="row-fluid">
+      <p><%= @profile.about_me %></p>
+    </div>
     <hr>
     <div class="row-fluid">
       <% if @profile.achievements.empty? %>
@@ -41,6 +36,15 @@
       <% @profile.achievements.each do |achievement| %>
         <%= render 'achievements/small', achievement: achievement %>
       <% end %>
+    </div>
+    <hr>
+    <div class="row-fluid">
+      <% if @profile.solutions.empty? %>
+          <p><%=@profile.user.username %> hasn't submitted any solutions...</p>
+      <% end %>
+      <ul id="solutions">
+        <%= render 'solutions/solutions' %>
+      </ul>
     </div>
   </div>
 </div>

--- a/vendor/assets/javascripts/konami.js
+++ b/vendor/assets/javascripts/konami.js
@@ -1,0 +1,101 @@
+/*
+	* Konami-JS ~ 
+	* :: Now with support for touch events and multiple instances for 
+	* :: those situations that call for multiple easter eggs!
+	* Code: http://konami-js.googlecode.com/
+	* Examples: http://www.snaptortoise.com/konami-js
+	* Copyright (c) 2009 George Mandis (georgemandis.com, snaptortoise.com)
+	* Version: 1.4.1 (3/1//2013)
+	* Licensed under the GNU General Public License v3
+	* http://www.gnu.org/copyleft/gpl.html
+	* Tested in: Safari 4+, Google Chrome 4+, Firefox 3+, IE7+, Mobile Safari 2.2.1 and Dolphin Browser
+*/
+
+var Konami = function(callback) {
+	var konami= {
+			addEvent:function ( obj, type, fn, ref_obj )
+			{
+				if (obj.addEventListener)
+					obj.addEventListener( type, fn, false );
+				else if (obj.attachEvent)
+				{
+					// IE
+					obj["e"+type+fn] = fn;
+					obj[type+fn] = function() { obj["e"+type+fn]( window.event,ref_obj ); }
+					obj.attachEvent( "on"+type, obj[type+fn] );
+				}
+			},
+	        input:"",
+	        pattern:"3838404037393739666513",		
+	        load: function(link) {					
+				this.addEvent(document,"keydown", function(e,ref_obj) {											
+					if (ref_obj) konami = ref_obj; // IE
+					konami.input+= e ? e.keyCode : event.keyCode;
+					if (konami.input.length > konami.pattern.length) konami.input = konami.input.substr((konami.input.length - konami.pattern.length));
+					if (konami.input == konami.pattern) {
+                    konami.code(link);
+					konami.input="";
+                   	return;
+                    }
+            	},this);
+           this.iphone.load(link);
+
+				},
+	        code: function(link) { window.location=link},
+	        iphone:{
+	                start_x:0,
+	                start_y:0,
+	                stop_x:0,
+	                stop_y:0,
+	                tap:false,
+	                capture:false,
+					orig_keys:"",
+	                keys:["UP","UP","DOWN","DOWN","LEFT","RIGHT","LEFT","RIGHT","TAP","TAP","TAP"],
+	                code: function(link) { konami.code(link);},
+	                load: function(link){
+									this.orig_keys = this.keys;
+	    							konami.addEvent(document,"touchmove",function(e){
+	                          if(e.touches.length == 1 && konami.iphone.capture==true){ 
+	                            var touch = e.touches[0]; 
+	                                konami.iphone.stop_x = touch.pageX;
+	                                konami.iphone.stop_y = touch.pageY;
+	                                konami.iphone.tap = false; 
+	                                konami.iphone.capture=false;
+	                                konami.iphone.check_direction();
+	                                }
+	                                });               
+	                        konami.addEvent(document,"touchend",function(evt){
+	                                if (konami.iphone.tap==true) konami.iphone.check_direction(link);           
+	                                },false);
+	                        konami.addEvent(document,"touchstart", function(evt){
+	                                konami.iphone.start_x = evt.changedTouches[0].pageX;
+	                                konami.iphone.start_y = evt.changedTouches[0].pageY;
+	                                konami.iphone.tap = true;
+	                                konami.iphone.capture = true;
+	                                });               
+	                                },
+	                check_direction: function(link){
+	                        x_magnitude = Math.abs(this.start_x-this.stop_x);
+	                        y_magnitude = Math.abs(this.start_y-this.stop_y);
+	                        x = ((this.start_x-this.stop_x) < 0) ? "RIGHT" : "LEFT";
+	                        y = ((this.start_y-this.stop_y) < 0) ? "DOWN" : "UP";
+	                        result = (x_magnitude > y_magnitude) ? x : y;
+	                        result = (this.tap==true) ? "TAP" : result;                     
+
+	                        if (result==this.keys[0]) this.keys = this.keys.slice(1,this.keys.length);
+	                        if (this.keys.length==0) { 
+								this.keys=this.orig_keys;
+								this.code(link);
+								}
+	                        }
+	                }
+	}
+	
+	typeof callback === "string" && konami.load(callback);
+	if(typeof callback === "function")  {
+		konami.code = callback;
+		konami.load();
+	}
+
+	return konami;
+}


### PR DESCRIPTION
Notes:
- The spinning will not stop until you reload the page or open another one. I feel like we shouldn't implement a feature to disable it, since it's not really needed.
- This will affect ALL `<i>` tags across the site. This shouldn't be an issue, since all that's happening is a CSS class being added on, but we might want to eventually change this so it only looks for `<i>` tags that are actually being used for icons (via a Query selectors with regex or something like that).
