### PR TITLE
Feature/coveralls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,9 @@ group :test do
   #gem 'simplecov', require: false
 end
 
+# Coveralls for code coverage... in the cloud!!!!1!1!!one!
+gem 'coveralls', require: false
+
 # To use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.0.0'
 

--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ group :development do
 end
 
 group :test do
-  gem 'simplecov', require: false
+  #gem 'simplecov', require: false
 end
 
 # To use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,10 +204,6 @@ GEM
     select2-rails (3.3.1)
       sass-rails (>= 3.2)
       thor (~> 0.14)
-    simplecov (0.7.1)
-      multi_json (~> 1.0)
-      simplecov-html (~> 0.7.1)
-    simplecov-html (0.7.1)
     sprockets (2.9.0)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -272,7 +268,6 @@ DEPENDENCIES
   sass-rails!
   select2-rails
   simple_form!
-  simplecov
   twitter-bootstrap-rails
   will_paginate
   yard (~> 0.8.5.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,13 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.6.2)
+    colorize (0.5.8)
+    coveralls (0.6.4)
+      colorize
+      multi_json (~> 1.3)
+      rest-client
+      simplecov (>= 0.7)
+      thor
     debug_inspector (0.0.2)
     erubis (2.7.0)
     execjs (1.4.0)
@@ -198,12 +205,18 @@ GEM
     rdoc (4.0.1)
       json (~> 1.4)
     redcarpet (2.2.2)
+    rest-client (1.6.7)
+      mime-types (>= 1.16)
     rvm-capistrano (1.2.7)
       capistrano (>= 2.0.0)
     sass (3.2.7)
     select2-rails (3.3.1)
       sass-rails (>= 3.2)
       thor (~> 0.14)
+    simplecov (0.7.1)
+      multi_json (~> 1.0)
+      simplecov-html (~> 0.7.1)
+    simplecov-html (0.7.1)
     sprockets (2.9.0)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -248,6 +261,7 @@ DEPENDENCIES
   capistrano
   closure-compiler
   coffee-rails!
+  coveralls
   devise!
   foreman
   gravatar-ultimate

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Codeflash](http://codeflash.thewcubed.com) [![Build Status](https://secure.travis-ci.org/codeflash/codeflash.png?branch=master)](http://travis-ci.org/codeflash/codeflash) [![Dependency Status](https://gemnasium.com/codeflash/codeflash.png)](https://gemnasium.com/codeflash/codeflash) [![Code Climate](https://codeclimate.com/github/codeflash/codeflash.png)](https://codeclimate.com/github/codeflash/codeflash)
+# [Codeflash](http://codeflash.thewcubed.com) [![Build Status](https://secure.travis-ci.org/codeflash/codeflash.png?branch=master)](http://travis-ci.org/codeflash/codeflash) [![Coverage Status](https://coveralls.io/repos/codeflash/codeflash/badge.png?branch=master)](https://coveralls.io/r/codeflash/codeflash) [![Dependency Status](https://gemnasium.com/codeflash/codeflash.png)](https://gemnasium.com/codeflash/codeflash) [![Code Climate](https://codeclimate.com/github/codeflash/codeflash.png)](https://codeclimate.com/github/codeflash/codeflash)
 
 Codeflash aims at being a community driven site for solving problems, both
 simple and complex. Codeflash will allow the community to decide what is the

--- a/script/rails
+++ b/script/rails
@@ -1,11 +1,11 @@
 #!/usr/bin/env ruby
 # This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
 
-if ENV['RAILS_ENV'] == 'test'
-    require 'simplecov'
-    SimpleCov.start 'rails'
-    puts "required simplecov"
-end
+#if ENV['RAILS_ENV'] == 'test'
+    #require 'simplecov'
+    #SimpleCov.start 'rails'
+    #puts "required simplecov"
+#end
 
 APP_PATH = File.expand_path('../../config/application',  __FILE__)
 require File.expand_path('../../config/boot',  __FILE__)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,6 @@
 # Set up code coverage with SimpleCov
-require 'simplecov'
-SimpleCov.start 'rails'
+#require 'simplecov'
+#SimpleCov.start 'rails'
 
 ENV["RAILS_ENV"] = "test"
 require File.expand_path('../../config/environment', __FILE__)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,7 @@
 
 # Set up code coverage with Coveralls
 require 'coveralls'
-Coveralls.wear!
+Coveralls.wear! 'rails'
 
 ENV["RAILS_ENV"] = "test"
 require File.expand_path('../../config/environment', __FILE__)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,10 @@
 #require 'simplecov'
 #SimpleCov.start 'rails'
 
+# Set up code coverage with Coveralls
+require 'coveralls'
+Coveralls.wear!
+
 ENV["RAILS_ENV"] = "test"
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'


### PR DESCRIPTION
![](http://i.imgur.com/AeACT0O.gif)

**Changes**
- Enable Coveralls for code coverage, which automatically runs on all our Travis builds (but **not** local builds).
- Disable Simplecov.
- Add code coverage badge to readme.
  I believe it may be possible to get Coveralls and Simplecov to peacefully coexist if need be.

**Notes**
- You will no longer get up-to-date coverage in the coverage directory with Simplecov, because Coveralls will handle our coverage in the cloud instead.
- Coveralls has awesome things like history of coverage changes over time and Travis integration.
- The code coverage badge is pointing to master, which does not have these changes yet. As a result, until these changes are merged into master, the badge will display that coverage is unknown.
